### PR TITLE
Make Node version explicit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
-language: node
+language: node_js
+node_js:
+  - '10'
 branches:
   only:
     - master


### PR DESCRIPTION
This is supposed to be the default in Travis but in fact it seems to be
running a comically old version