### PR TITLE
Select separate due date for projects

### DIFF
--- a/src/clients/google/addLessonToClassroom.js
+++ b/src/clients/google/addLessonToClassroom.js
@@ -9,6 +9,7 @@ import {loadAndConfigureGapi} from '../../services/gapi';
 export default async function addLessonToClassroom({
   course: {id: courseId},
   date,
+  dueDate,
   lessonPlan: {
     doNowPrompt,
     doNowStarterCodeUrl,
@@ -27,6 +28,7 @@ export default async function addLessonToClassroom({
 }) {
   const startDateTime = dateTime(date, startTime);
   const endDateTime = dateTime(date, endTime);
+  const dueDateTime = dateTime(dueDate || date, endTime);
 
   const [
     doNowAssignment,
@@ -43,7 +45,7 @@ export default async function addLessonToClassroom({
 
     addSlides({
       courseId,
-      endDateTime,
+      dueDateTime,
       guidedNotes,
       homework,
       independentPracticeStarterCodeUrl,
@@ -102,7 +104,7 @@ async function addDoNow({
 
 async function addSlides({
   courseId,
-  endDateTime,
+  dueDateTime,
   lessonId,
   independentPracticeStarterCodeUrl,
   isProject,
@@ -113,7 +115,7 @@ async function addSlides({
   title,
   vocabulary,
 }) {
-  const dueDateTime = addMinutes(endDateTime, 10);
+  const dueDateTimeWithGracePeriod = addMinutes(dueDateTime, 10);
 
   let description = `Objective: ${objective}`;
   if (vocabulary) {
@@ -122,8 +124,8 @@ async function addSlides({
 
   const resource = {
     description,
-    dueDate: apiDate(dueDateTime),
-    dueTime: apiTime(dueDateTime),
+    dueDate: apiDate(dueDateTimeWithGracePeriod),
+    dueTime: apiTime(dueDateTimeWithGracePeriod),
     materials: [{driveFile: {driveFile: {id: slides.id}}}],
     maxPoints: isProject ? 100 : 0,
     scheduledTime: apiTimestamp(addMinutes(startDateTime, -5)),

--- a/src/clients/google/index.js
+++ b/src/clients/google/index.js
@@ -8,6 +8,8 @@ import sortBy from 'lodash-es/sortBy';
 
 import {getGapiSync, loadAndConfigureGapi} from '../../services/gapi';
 
+import {loadAllPages} from './requests';
+
 const MASTER_CURRICULUM_FOLDER_ID =
   process.env.REACT_APP_MASTER_CURRICULUM_FOLDER_ID;
 
@@ -17,14 +19,9 @@ const IRREGULAR_UNIT_NAMES = {
   'Midyear Challenge and Review Unit 18-19': 5.5,
 };
 
-const LESSON_MATERIAL_ABBREVIATIONS = {
-  'GN': 'guidedNotes',
-  'HW': 'homework',
-  'LP': 'slides',
-};
-
-export {default as copyLesson} from './copyLesson';
 export {default as addLessonToClassroom} from './addLessonToClassroom';
+export {default as copyLesson} from './copyLesson';
+export {default as loadLessons} from './loadLessons';
 
 export async function init() {
   return loadAndConfigureGapi();
@@ -73,78 +70,6 @@ export async function loadUnits() {
   );
 }
 
-export async function loadLessons({id: unitId}) {
-  const {client: {drive}} = await loadAndConfigureGapi();
-
-  const lessonMap = new Map();
-  const eachPage = loadEachPage(pageToken => drive.files.list({
-    q: `'${escapeQuotes(unitId)}' in parents`,
-    fields: ['files(exportLinks,id,mimeType,name,webViewLink)']
-  }));
-
-  for await (const {files} of eachPage) {
-    for (const file of files) {
-      const {type, index} = identifyLessonFile(file) || {};
-
-      if (type) {
-        if (!lessonMap.has(index)) {
-          lessonMap.set(index, {});
-        }
-        const lesson = lessonMap.get(index);
-        lesson[type] = file;
-      }
-    }
-  }
-
-  return sortLessons(Array.from(lessonMap.entries()));
-}
-
-function identifyLessonFile(file) {
-  const parsedFilename =
-    /^(?:\d+)\.(\d+|PR?\d?) (?:([A-Z]{2}) )?(?:.+)$/.exec(file.name);
-  if (parsedFilename) {
-    const [, index, typeAbbreviation] = parsedFilename;
-    if (typeAbbreviation in LESSON_MATERIAL_ABBREVIATIONS) {
-      return {
-        index,
-        type: LESSON_MATERIAL_ABBREVIATIONS[typeAbbreviation],
-      };
-    } else if (!typeAbbreviation) {
-      if (index.startsWith('PR')) {
-        return {
-          index: index.replace(/^PR/, 'P'),
-          type: 'rubric',
-        };
-      } else if (file.mimeType === 'application/vnd.google-apps.presentation') {
-        return {
-          index,
-          type: 'slides',
-        };
-      }
-    }
-  }
-}
-
-function sortLessons(lessons) {
-  return map(
-    lessons.sort(
-      ([index1], [index2]) => {
-        const lesson1IsProject = index1.startsWith('P');
-        const lesson2IsProject = index2.startsWith('P');
-
-        if (lesson1IsProject && !lesson2IsProject) return 1;
-        if (lesson2IsProject && !lesson1IsProject) return -1;
-
-        const numericIndex1 = Number(/\d+$/.exec(index1)[0]);
-        const numericIndex2 = Number(/\d+$/.exec(index2)[0]);
-
-        return numericIndex1 - numericIndex2;
-      }
-    ),
-    last
-  );
-}
-
 export async function getFolderDetails({url}) {
   const {pathname} = parse(url);
   const fileId = last(pathname.split('/'));
@@ -160,22 +85,4 @@ export async function loadCourses() {
     pageToken => classroom.courses.list({teacherId: 'me'}),
     property('courses'),
   );
-}
-
-async function loadAllPages(getPage, getItems) {
-  const items = [];
-  for await (const result of loadEachPage(getPage)) {
-    items.push(...getItems(result));
-  }
-
-  return items;
-}
-
-async function* loadEachPage(getPage) {
-  let pageToken;
-  do {
-    const {result} = await getPage(pageToken);
-    yield result;
-    pageToken = result.nextPageToken;
-  } while (pageToken);
 }

--- a/src/clients/google/loadLessons.js
+++ b/src/clients/google/loadLessons.js
@@ -1,7 +1,6 @@
 import escapeQuotes from 'escape-quotes';
+import filter from 'lodash-es/filter';
 import isNil from 'lodash-es/isNil';
-import last from 'lodash-es/last';
-import map from 'lodash-es/map';
 import merge from 'lodash-es/merge';
 
 import {loadAndConfigureGapi} from '../../services/gapi';
@@ -34,12 +33,16 @@ export default async function loadLessons({id: unitId}) {
     }
   }
 
-  return sortLessons(Array.from(lessonMap.values()));
+  return sortLessons(filter(
+    Array.from(lessonMap.values()),
+    'materials.slides',
+  ));
 }
 
 function identifyLessonFile(file) {
   const parsedFilename =
-    /^(\d+\.(\d+)|PR?(\d?)) (?:([A-Z]{2}) )?(.+)(?: \d{4}-\d{4})?$/.exec(file.name);
+    /^(\d+\.(?:(\d+)|PR?(\d?))) (?:([A-Z]{2}) )?(.+?)(?: \d{2,4}-\d{2,4})?$/
+      .exec(file.name);
   if (parsedFilename) {
     const [
       fullMatch,

--- a/src/clients/google/loadLessons.js
+++ b/src/clients/google/loadLessons.js
@@ -1,0 +1,85 @@
+import escapeQuotes from 'escape-quotes';
+import last from 'lodash-es/last';
+import map from 'lodash-es/map';
+
+import {loadAndConfigureGapi} from '../../services/gapi';
+
+import {loadEachPage} from './requests';
+
+const LESSON_MATERIAL_ABBREVIATIONS = {
+  'GN': 'guidedNotes',
+  'HW': 'homework',
+  'LP': 'slides',
+};
+
+export default async function loadLessons({id: unitId}) {
+  const {client: {drive}} = await loadAndConfigureGapi();
+
+  const lessonMap = new Map();
+  const eachPage = loadEachPage(pageToken => drive.files.list({
+    q: `'${escapeQuotes(unitId)}' in parents`,
+    fields: ['files(exportLinks,id,mimeType,name,webViewLink)']
+  }));
+
+  for await (const {files} of eachPage) {
+    for (const file of files) {
+      const {type, index} = identifyLessonFile(file) || {};
+
+      if (type) {
+        if (!lessonMap.has(index)) {
+          lessonMap.set(index, {});
+        }
+        const lesson = lessonMap.get(index);
+        lesson[type] = file;
+      }
+    }
+  }
+
+  return sortLessons(Array.from(lessonMap.entries()));
+}
+
+function identifyLessonFile(file) {
+  const parsedFilename =
+    /^(?:\d+)\.(\d+|PR?\d?) (?:([A-Z]{2}) )?(?:.+)$/.exec(file.name);
+  if (parsedFilename) {
+    const [, index, typeAbbreviation] = parsedFilename;
+    if (typeAbbreviation in LESSON_MATERIAL_ABBREVIATIONS) {
+      return {
+        index,
+        type: LESSON_MATERIAL_ABBREVIATIONS[typeAbbreviation],
+      };
+    } else if (!typeAbbreviation) {
+      if (index.startsWith('PR')) {
+        return {
+          index: index.replace(/^PR/, 'P'),
+          type: 'rubric',
+        };
+      } else if (file.mimeType === 'application/vnd.google-apps.presentation') {
+        return {
+          index,
+          type: 'slides',
+        };
+      }
+    }
+  }
+}
+
+function sortLessons(lessons) {
+  return map(
+    lessons.sort(
+      ([index1], [index2]) => {
+        const lesson1IsProject = index1.startsWith('P');
+        const lesson2IsProject = index2.startsWith('P');
+
+        if (lesson1IsProject && !lesson2IsProject) return 1;
+        if (lesson2IsProject && !lesson1IsProject) return -1;
+
+        const numericIndex1 = Number(/\d+$/.exec(index1)[0]);
+        const numericIndex2 = Number(/\d+$/.exec(index2)[0]);
+
+        return numericIndex1 - numericIndex2;
+      }
+    ),
+    last
+  );
+}

--- a/src/clients/google/requests.js
+++ b/src/clients/google/requests.js
@@ -1,0 +1,17 @@
+export async function loadAllPages(getPage, getItems) {
+  const items = [];
+  for await (const result of loadEachPage(getPage)) {
+    items.push(...getItems(result));
+  }
+
+  return items;
+}
+
+export async function* loadEachPage(getPage) {
+  let pageToken;
+  do {
+    const {result} = await getPage(pageToken);
+    yield result;
+    pageToken = result.nextPageToken;
+  } while (pageToken);
+}

--- a/src/components/AddToClassroom.jsx
+++ b/src/components/AddToClassroom.jsx
@@ -6,9 +6,9 @@ import {addLessonToClassroom} from '../clients/google';
 export default function AddToClassroom({
   course,
   date,
+  lesson,
   lessonPlan,
   programDetails,
-  programMaterials,
   onComplete,
 }) {
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -24,9 +24,9 @@ export default function AddToClassroom({
             await addLessonToClassroom({
               course,
               date,
+              lesson,
               lessonPlan,
               programDetails,
-              programMaterials,
             }),
           );
         }}

--- a/src/components/AddToClassroom.jsx
+++ b/src/components/AddToClassroom.jsx
@@ -6,6 +6,7 @@ import {addLessonToClassroom} from '../clients/google';
 export default function AddToClassroom({
   course,
   date,
+  dueDate,
   lesson,
   lessonPlan,
   programDetails,
@@ -24,6 +25,7 @@ export default function AddToClassroom({
             await addLessonToClassroom({
               course,
               date,
+              dueDate,
               lesson,
               lessonPlan,
               programDetails,

--- a/src/components/CloneProgramMaterials.jsx
+++ b/src/components/CloneProgramMaterials.jsx
@@ -10,7 +10,6 @@ import {getFolderDetails, copyLesson} from '../clients/google';
 import CenterAll from './layout/CenterAll';
 
 export default function CloneProgramMaterials({
-  date,
   masterMaterials,
   programDetails: {lessonMaterialsFolderUrl, programPrefix},
   onCloned,

--- a/src/components/DatePicker.jsx
+++ b/src/components/DatePicker.jsx
@@ -15,12 +15,16 @@ function nextWeekday(date = new Date()) {
   return nextDay;
 }
 
-export default function DatePicker({onPick}) {
-  const [selected, updateSelected] = useState(nextWeekday());
+export default function DatePicker({
+  defaultDate = nextWeekday(),
+  header = 'When is the program session?',
+  onPick,
+}) {
+  const [selected, updateSelected] = useState(defaultDate);
 
   return (
     <CenterAll>
-      <h2>When is the program session?</h2>
+      <h2>{header}</h2>
       <div>
         <ReactDatePicker
           inline

--- a/src/components/LessonPicker.jsx
+++ b/src/components/LessonPicker.jsx
@@ -16,8 +16,8 @@ export default function LessonPicker({unit, onPick}) {
 
   return (
     <Picker
-      itemKey="slides.id"
-      itemLabel="slides.name"
+      itemKey="lessonId"
+      itemLabel="title"
       items={lessons}
       header="Select a lesson:"
       onPick={onPick}

--- a/src/components/LessonPicker.jsx
+++ b/src/components/LessonPicker.jsx
@@ -17,7 +17,7 @@ export default function LessonPicker({unit, onPick}) {
   return (
     <Picker
       itemKey="lessonId"
-      itemLabel="title"
+      itemLabel={({lessonId, title}) => `${lessonId}: ${title}`}
       items={lessons}
       header="Select a lesson:"
       onPick={onPick}

--- a/src/components/LessonPlanner.jsx
+++ b/src/components/LessonPlanner.jsx
@@ -18,9 +18,9 @@ export default function LessonPlanner() {
   const [course, setCourse] = useState();
   const [date, setDate] = useState();
   const [lessonPlan, setLessonPlan] = useState();
-  const [masterMaterials, setMasterMaterials] = useState();
+  const [masterLesson, setMasterLesson] = useState();
   const [programDetails, setProgramDetails] = useState();
-  const [programMaterials, setProgramMaterials] = useState();
+  const [programLesson, setProgramLesson] = useState();
   const [unit, setUnit] = useState();
 
   if (isUndefined(course)) {
@@ -34,20 +34,22 @@ export default function LessonPlanner() {
     );
   } else if (isUndefined(unit))  {
     return <UnitPicker onPick={setUnit} />;
-  } else if (isUndefined(masterMaterials)) {
+  } else if (isUndefined(masterLesson)) {
     return (
       <LessonPicker
         unit={unit}
-        onPick={setMasterMaterials}
+        onPick={setMasterLesson}
       />
     );
-  } else if (isUndefined(programMaterials)) {
+  } else if (isUndefined(programLesson)) {
     return (
       <CloneProgramMaterials
         date={date}
-        masterMaterials={masterMaterials}
+        masterMaterials={masterLesson.materials}
         programDetails={programDetails}
-        onCloned={setProgramMaterials}
+        onCloned={(materials) => {
+          setProgramLesson({...masterLesson, materials});
+        }}
       />
     );
   } else if (isUndefined(date)) {
@@ -55,7 +57,7 @@ export default function LessonPlanner() {
   } else if (isUndefined(lessonPlan)) {
     return (
       <LessonForm
-        lessonMaterials={programMaterials}
+        lessonMaterials={programLesson.materials}
         onSubmit={setLessonPlan}
       />
     );
@@ -64,9 +66,9 @@ export default function LessonPlanner() {
       <AddToClassroom
         course={course}
         date={date}
+        lesson={programLesson}
         lessonPlan={lessonPlan}
         programDetails={programDetails}
-        programMaterials={programMaterials}
         onComplete={setClassroomMaterials}
       />
     );
@@ -75,10 +77,10 @@ export default function LessonPlanner() {
       <CenterAll>
         <p>Program: {course.name}</p>
         <p>Unit: {unit.name}</p>
-        <p>Lesson: {masterMaterials.slides.name}</p>
+        <p>Lesson: {programLesson.materials.slides.name}</p>
         <p>Date: {format(date, 'MMMM d')}</p>
         <p>Program materials:</p>
-        <LessonMaterials lessonMaterials={programMaterials} />
+        <LessonMaterials lessonMaterials={programLesson.materials} />
         <p>
           <a
             href={course.alternateLink}

--- a/src/components/LessonPlanner.jsx
+++ b/src/components/LessonPlanner.jsx
@@ -55,7 +55,15 @@ export default function LessonPlanner() {
     );
   } else if (isNil(date)) {
     return <DatePicker onPick={setDate} />;
-  } else if (isUndefined(lessonPlan)) {
+  } else if (masterLesson.isProject && isNil(dueDate)) {
+    return (
+      <DatePicker
+        defaultDate={date}
+        header='When is the project due?'
+        onPick={setDueDate}
+      />
+    );
+  } else if (isNil(lessonPlan)) {
     return (
       <LessonForm
         lessonMaterials={programLesson.materials}
@@ -67,6 +75,7 @@ export default function LessonPlanner() {
       <AddToClassroom
         course={course}
         date={date}
+        dueDate={dueDate}
         lesson={programLesson}
         lessonPlan={lessonPlan}
         programDetails={programDetails}

--- a/src/components/LessonPlanner.jsx
+++ b/src/components/LessonPlanner.jsx
@@ -1,5 +1,5 @@
 import format from 'date-fns/format';
-import isUndefined from 'lodash-es/isUndefined';
+import isNil from 'lodash-es/isNil';
 import React, {useState} from 'react';
 
 import AddToClassroom from './AddToClassroom';
@@ -17,31 +17,32 @@ export default function LessonPlanner() {
   const [classroomMaterials, setClassroomMaterials] = useState();
   const [course, setCourse] = useState();
   const [date, setDate] = useState();
+  const [dueDate, setDueDate] = useState();
   const [lessonPlan, setLessonPlan] = useState();
   const [masterLesson, setMasterLesson] = useState();
   const [programDetails, setProgramDetails] = useState();
   const [programLesson, setProgramLesson] = useState();
   const [unit, setUnit] = useState();
 
-  if (isUndefined(course)) {
+  if (isNil(course)) {
     return <CoursePicker onPick={setCourse} />;
-  } else if (isUndefined(programDetails)) {
+  } else if (isNil(programDetails)) {
     return (
       <ProgramForm
         course={course}
         onSubmit={setProgramDetails}
       />
     );
-  } else if (isUndefined(unit))  {
+  } else if (isNil(unit))  {
     return <UnitPicker onPick={setUnit} />;
-  } else if (isUndefined(masterLesson)) {
+  } else if (isNil(masterLesson)) {
     return (
       <LessonPicker
         unit={unit}
         onPick={setMasterLesson}
       />
     );
-  } else if (isUndefined(programLesson)) {
+  } else if (isNil(programLesson)) {
     return (
       <CloneProgramMaterials
         date={date}
@@ -52,7 +53,7 @@ export default function LessonPlanner() {
         }}
       />
     );
-  } else if (isUndefined(date)) {
+  } else if (isNil(date)) {
     return <DatePicker onPick={setDate} />;
   } else if (isUndefined(lessonPlan)) {
     return (
@@ -61,7 +62,7 @@ export default function LessonPlanner() {
         onSubmit={setLessonPlan}
       />
     );
-  } else if (isUndefined(classroomMaterials)) {
+  } else if (isNil(classroomMaterials)) {
     return (
       <AddToClassroom
         course={course}

--- a/src/components/Picker.jsx
+++ b/src/components/Picker.jsx
@@ -14,7 +14,7 @@ export default function Picker({
   onPick,
 }) {
   const getItemKey = isFunction(itemKey) ? itemKey : property(itemKey);
-  const getItemLabel = isFunction(itemLabel) ? itemKey : property(itemLabel);
+  const getItemLabel = isFunction(itemLabel) ? itemLabel : property(itemLabel);
 
   return (
     isNull(items) ? (


### PR DESCRIPTION
Closes #6

Workflow now includes a picker for the project due date, if a project is selected. This becomes the due date of the main assignment in Google Classroom.

Triggered a refector whereby `loadLessons` now returns objects that retain lesson metadata extracted from file names: the lesson ID (e.g. `06.4` or `08.P2`), whether it is a project, cleaned up title, etc. Lessons have a `materials` property which is an object mapping file type to file reference. This allows us to make decisions based on project status anywhere in the flow, and eliminates some duplicative parsing from `addLessonToClassroom`.